### PR TITLE
Fixing 'Your web server is not properly set up to resolve "/ocm-provi…

### DIFF
--- a/templates/nginx_nc.j2
+++ b/templates/nginx_nc.j2
@@ -124,7 +124,7 @@ server {
         deny all;
     }
 
-    location ~ ^/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+|core/templates/40[34])\.php(?:$|/) {
+    location ~ ^/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|oc[ms]-provider/.+|core/templates/40[34])\.php(?:$|/) {
         # include fastcgi_params;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
@@ -139,7 +139,7 @@ server {
         #fastcgi_request_buffering off;
     }
 
-    location ~ ^/(?:updater|ocs-provider)(?:$|/) {
+    location ~ ^/(?:updater|oc[ms]-provider)(?:$|/) {
         try_files $uri/ =404;
         index index.php;
     }


### PR DESCRIPTION
…der/".'

Fixing this error:
```
There are some warnings regarding your setup.
    Your web server is not properly set up to resolve "/ocm-provider/". This is most likely related to a web server configuration that was not updated to deliver this folder directly. Please compare your configuration against the shipped rewrite rules in ".htaccess" for Apache or the provided one in the documentation for Nginx at it's documentation page. On Nginx those are typically the lines starting with "location ~" that need an update.
```

Using code from here:
https://docs.nextcloud.com/server/16/admin_manual/installation/nginx.html